### PR TITLE
fix: failed to generate report

### DIFF
--- a/run.py
+++ b/run.py
@@ -82,7 +82,7 @@ def run_one_report(air, dev):
                 "--lang",
                 "zh"
             ]
-            ret = subprocess.call(cmd, shell=True, cwd=os.getcwd())
+            ret = subprocess.call(cmd, cwd=os.getcwd())
             return {
                     'status': ret,
                     'path': os.path.join(log_dir, 'log.html')


### PR DESCRIPTION
shell=True 参数导致命令行解析错误。airtest report 这个命令本身就包含空格,使用 shell=True 会导致错误解析命令行而失败

导致最后没有生成报告。